### PR TITLE
Allow Kayo API to choose CDN provider

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -73,10 +73,7 @@ class API(object):
         return self._session.get('https://resources.kayosports.com.au/production/sport-menu/lists/default.json').json()
 
     def cdn_selection(self):
-        cdn = self._session.get('https://cdnselectionserviceapi.kayosports.com.au/android/usecdn/mobile/live').json().get('useCDN')
-        if not cdn:
-            return 'AKAMAI'
-        return cdn
+        return self._session.get('https://cdnselectionserviceapi.kayosports.com.au/android/usecdn/mobile/live').json().get('useCDN', 'AKAMAI')
 
     #landing has heros and panels
     def landing(self, name, **kwargs):

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -72,6 +72,12 @@ class API(object):
     def sport_menu(self):
         return self._session.get('https://resources.kayosports.com.au/production/sport-menu/lists/default.json').json()
 
+    def cdn_selection(self):
+        cdn = self._session.get('https://cdnselectionserviceapi.kayosports.com.au/android/usecdn/mobile/live').json().get('useCDN')
+        if not cdn:
+            return 'AKAMAI'
+        return cdn
+
     #landing has heros and panels
     def landing(self, name, **kwargs):
         params = {

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -161,9 +161,10 @@ def _get_stream(asset):
     streams = [asset['recommendedStream']]
     streams.extend(asset['alternativeStreams'])
 
+    cdn = api.cdn_selection()
     playable = ['hls-ts', 'dash']
     streams  = [s for s in streams if s['mediaFormat'] in playable]
-    streams  = sorted(streams, key=lambda k: (k['mediaFormat'] == 'hls-ts', k['provider'] == 'AKAMAI'), reverse=True)
+    streams  = sorted(streams, key=lambda k: (k['mediaFormat'] == 'hls-ts', k['provider'] == cdn), reverse=True)
 
     if not streams:
         raise PluginError(_.NO_STREAM)


### PR DESCRIPTION
There's been a few reports on the whirlpool addon thread as well as the main kayo thread about streams stuttering during certain peak times. Hopefully this may help with that, or at the very least distribute the load as Kayo would have it.

The url for this API call also takes a 'sport' param which may or may not affect the outcome but since that data isn't contained in the stream asset I've kept it simple.